### PR TITLE
fix: misconfigured eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,16 +2,23 @@ const ts = require('typescript-eslint');
 const js = require('@eslint/js');
 const prettier = require('eslint-config-prettier');
 
-module.exports = [
+module.exports = ts.config(
   js.configs.recommended,
-  ts.configs.eslintRecommended,
+  ...ts.configs.recommended,
   prettier,
   {
     ignores: ['lib/**'],
   },
   {
+    files: ['*.js'],
+    rules: {
+      '@typescript-eslint/no-var-requires': 'off',
+    },
+  },
+  {
     languageOptions: {
       globals: {
+        __dirname: true,
         console: true,
         exports: true,
         module: true,
@@ -19,4 +26,4 @@ module.exports = [
       },
     },
   },
-];
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
 export function helloWorld() {
   return 'Hello World!';
 }
+
+export interface Greeter {
+  greet(): string;
+}
+
+export class HelloWorldGreeter implements Greeter {
+  greet() {
+    return 'Hello World!';
+  }
+}


### PR DESCRIPTION
## Description

Eslint wasn't quite configured correctly and missed a lot of the TypeScript syntax.
Added additional code to catch these cases in the future.