### PR TITLE
chore: Small config improvements

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-npx pretty-quick --staged
+npx pretty-quick --staged --pattern "**/*.{js,ts,mjs,cjs}"
 npm run lint

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ export default ts.config(
   {
     files: ['*.js'],
     rules: {
-      '@typescript-eslint/no-var-requires': 'off',
+      '@typescript-eslint/no-require-imports': 'off',
     },
   },
   {


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

* `@typescript-eslint/no-var-requires` is deprecated and replaced by `@typescript-eslint/no-require-imports`
* Configure pretty-quick to run against the same file pattern that the lint and fmt scripts run against. Noticed this when pretty-quick tried to change `"` to `'` in a github workflow config yaml file.
